### PR TITLE
Add WebSocket service and gateway for real-time updates

### DIFF
--- a/cmd/like-service/server/main.go
+++ b/cmd/like-service/server/main.go
@@ -90,7 +90,7 @@ func main() {
 	defer pw.Close()
 
 	// create consumer
-	consumer, err := pw.CreateConsumer(cfg.Queue.TopicName, "test-subscription", pulsar.Shared)
+	consumer, err := pw.CreateConsumer(cfg.Queue.TopicName, "witty-subscription", pulsar.Shared)
 	if err != nil {
 		slog.Error("failed to create consumer", "error", err)
 		os.Exit(1)

--- a/cmd/like-service/websocket/gateway.go
+++ b/cmd/like-service/websocket/gateway.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/coder/websocket"
+	likev1 "github.com/yaninyzwitty/go-live-counter/gen/like/v1"
+	"github.com/yaninyzwitty/go-live-counter/gen/like/v1/likev1connect"
+	"github.com/yaninyzwitty/go-live-counter/internal/config"
+	"golang.org/x/net/http2"
+)
+
+// gatewayServer bridges WebSocket ↔ gRPC streaming.
+type gatewayServer struct {
+	cfg    *config.Config
+	logger *slog.Logger
+}
+
+func (s *gatewayServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	c, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		s.logger.Error("failed to accept handshake", "error", err)
+		return
+	}
+
+	defer c.CloseNow()
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	postID := r.URL.Query().Get("post_id")
+	if postID == "" {
+		postID = "5cd0cb60-4d98-479a-b226-c7130362fa8b"
+	}
+
+	req := connect.NewRequest(&likev1.StreamLikesRequest{
+		PostId: postID,
+	})
+	// start stream with h2c support
+	tr := &http2.Transport{
+		AllowHTTP: true,
+		DialTLS: func(network, addr string, cfg *tls.Config) (net.Conn, error) {
+			return net.Dial(network, addr)
+		},
+	}
+	httpClient := &http.Client{Transport: tr}
+	likeServiceURL := fmt.Sprintf("http://localhost:%d", s.cfg.LikeService.Port)
+	likeClient := likev1connect.NewLikeServiceClient(httpClient, likeServiceURL)
+
+	stream, err := likeClient.StreamLikes(ctx, req)
+	if err != nil {
+		s.logger.Error("failed to open grpc likes stream", "error", err)
+		c.Close(websocket.StatusInternalError, "failed to connect upstream")
+		return
+	}
+
+	// Watch client disconnects by reading frames
+	go func() {
+		for {
+			if _, _, err := c.Read(ctx); err != nil {
+				cancel()
+				return
+			}
+		}
+	}()
+
+	// Relay upstream messages to websocket client
+	for stream.Receive() {
+		update := stream.Msg()
+		slog.Info("like update received",
+			"post_id", update.PostId,
+			"total_likes", update.TotalLikes,
+			"liked_at", update.LikedAt.AsTime(),
+		)
+		payload := struct {
+			PostID     string `json:"post_id"`
+			TotalLikes int64  `json:"total_likes"`
+			LikedAt    string `json:"liked_at"`
+		}{
+			PostID:     update.PostId,
+			TotalLikes: update.TotalLikes,
+			LikedAt:    update.LikedAt.AsTime().UTC().Format(time.RFC3339),
+		}
+
+		b, err := json.Marshal(payload)
+		if err != nil {
+			s.logger.Error("failed to marshal update", "error", err)
+			continue
+		}
+
+		if err := c.Write(ctx, websocket.MessageText, b); err != nil {
+			s.logger.Error("failed to write to websocket", "error", err)
+			cancel()
+			break
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		s.logger.Info("upstream stream closed", "error", err)
+	}
+}

--- a/cmd/like-service/websocket/main.go
+++ b/cmd/like-service/websocket/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/yaninyzwitty/go-live-counter/internal/config"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(logger)
+
+	// Load config
+	var cfg config.Config
+	if err := cfg.LoadConfig("config.yaml"); err != nil {
+		logger.Error("Failed to load config", "error", err)
+		os.Exit(1)
+	}
+
+	websocketAddr := fmt.Sprintf(":%d", cfg.Websocket.Port)
+
+	// create a listener
+	lis, err := net.Listen("tcp", websocketAddr)
+	if err != nil {
+		slog.Error("failed to listen ", "error", err)
+		os.Exit(1)
+	}
+
+	slog.Info("listening", "endpoint", "ws://"+lis.Addr().String())
+
+	mux := http.NewServeMux()
+	mux.Handle("/ws", &gatewayServer{cfg: &cfg, logger: logger})
+	server := &http.Server{
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	if err := server.Serve(lis); err != nil {
+		logger.Error("websocket gateway stopped", "error", err)
+	}
+}

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,8 @@ like-service:
   port: 50053
 outbox-service:
   port: 50054
+websocket-service:
+  port: 50055
 database:
   username: yaninyzwitty
   host: vague-echidna-13927.j77.aws-eu-central-1.cockroachlabs.cloud

--- a/example.txt
+++ b/example.txt
@@ -1,31 +1,4 @@
-package main
-
-import (
-	"context"
-	"fmt"
-	"log/slog"
-	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
-
-	"connectrpc.com/connect"
-	likev1 "github.com/yaninyzwitty/go-live-counter/gen/like/v1"
-	"github.com/yaninyzwitty/go-live-counter/gen/like/v1/likev1connect"
-	"github.com/yaninyzwitty/go-live-counter/internal/config"
-)
-
-func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	slog.SetDefault(logger)
-
-	// Load config
-	var cfg config.Config
-	if err := cfg.LoadConfig("config.yaml"); err != nil {
-		logger.Error("Failed to load config", "error", err)
-		os.Exit(1)
-	}
-	// Setup client
+// Setup client
 	httpClient := http.DefaultClient
 	likeServiceURL := fmt.Sprintf("http://localhost:%d", cfg.LikeService.Port)
 	likeClient := likev1connect.NewLikeServiceClient(httpClient, likeServiceURL)
@@ -59,5 +32,3 @@ func main() {
 	if err := stream.Err(); err != nil {
 		slog.Error("stream ended with error", "error", err)
 	}
-
-}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.4.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/coder/websocket v1.8.13 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/dvsekhvalnov/jose2go v1.6.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqy
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coder/websocket v1.8.13 h1:f3QZdXy7uGVz+4uCJy2nTZyM0yTBj8yANEHhqlXZ9FE=
+github.com/coder/websocket v1.8.13/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/containerd/containerd v1.7.27 h1:yFyEyojddO3MIGVER2xJLWoCIn+Up4GaHFquP7hsFII=
 github.com/containerd/containerd v1.7.27/go.mod h1:xZmPnl75Vc+BLGt4MIfu6bp+fy03gdHAn9bz+FreFR0=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	UserService Service     `yaml:"user-service"`
 	LikeService Service     `yaml:"like-service"`
 	PostService Service     `yaml:"post-service"`
+	Websocket   Service     `yaml:"websocket-service"`
 	Outbox      Service     `yaml:"outbox-service"`
 	Database    Cocroach    `yaml:"database"`
 	Queue       PulsarQueue `yaml:"queue"`


### PR DESCRIPTION
- Introduced a new WebSocket service in the configuration to handle real-time like updates.
- Implemented a WebSocket gateway to bridge WebSocket connections with gRPC streaming for likes.
- Enhanced the Like service to support WebSocket connections, allowing clients to receive live updates.
- Updated the main entry point for the WebSocket service to set up the server and handle incoming connections.
- Added necessary dependencies for WebSocket functionality in go.mod and updated related files accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a WebSocket gateway that streams real-time like updates to clients, with graceful handling of disconnects and errors.
  * Added configuration for the WebSocket service (default port 50055); the service now starts on the configured port.

* **Documentation**
  * Added an example client demonstrating how to consume streaming like updates.

* **Chores**
  * Included a websocket dependency to support the new gateway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->